### PR TITLE
Remove flutter from depedencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+* Removed Flutter from the dependencies. This will allow to use the package as a pure Dart library (i.e. backend or AngularDart).
+
 ## 1.0.1
 * Removing Android and iOS folder as they aren't needed for this package.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,3 @@ environment:
 dev_dependencies:
   test: ^1.6.0
 
-# The following section is specific to Flutter.
-flutter:
-  uses-material-design: false
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,7 @@ homepage: https://github.com/mtwichel/square-connect-flutter-library
 environment:
   sdk: ">=2.2.2 <3.0.0"
 
-dependencies:
-  flutter:
-    sdk: flutter
-
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   test: ^1.6.0
 
 # The following section is specific to Flutter.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_connect
 description: A wrapper for the Square Connect APIs. It's intended use is in a flutter application to manage inventory, catalog, customers, labor, and more on the Square platform.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/mtwichel/square-connect-flutter-library
 
 environment:

--- a/test/catalog_api_test.dart
+++ b/test/catalog_api_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:square_connect/square_connect.dart';
+import 'package:test/test.dart';
 
 import 'square_connect_test.dart';
 

--- a/test/customer_api_test.dart
+++ b/test/customer_api_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:square_connect/square_connect.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('From JSON', () {

--- a/test/square_connect_test.dart
+++ b/test/square_connect_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:square_connect/square_connect.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('parse duration', () {});


### PR DESCRIPTION
The library does not require Flutter as a dependency anymore.

By removing the dependency we will able to use library in project that are not related to Flutter, like AngularDart.